### PR TITLE
Change echo to Exception in case function not found

### DIFF
--- a/src/Exchange.php
+++ b/src/Exchange.php
@@ -1459,7 +1459,7 @@ abstract class Exchange {
             return call_user_func_array ($this->$function, $params);
         else {
             /* handle errors */
-            echo $function . ' not found';
+            throw new ExchangeError ( $function . ' not found');
         }
     }
 


### PR DESCRIPTION
I had some unwanted outputs because of this 'echo' and I propose to change it as an Exception so it could be catched like other errors and handled properly.